### PR TITLE
disable local cache

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,2 +1,0 @@
-build --experimental_local_disk_cache
-build --experimental_local_disk_cache_path=.bazel_cache


### PR DESCRIPTION
Starting with Bazel 0.14 these flags no longer exist and have been replaced by
the --disk_cache flag. We want to maintain compatibility with older Bazel versions
and thus we have to remove these flags for now.

@dslomov @ittaiz